### PR TITLE
Add support for a video ATOD and update README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ init:
 
 config:
 	sed -i 's|ExecStart=.*|ExecStart=python ${PWD}/apodwallpaper.py|g' apodwallpaper.service
-	sed -i "s|apodPath =.*|apodPath = \'${PWD}/apod-image.png\'|g" apodwallpaper.py
 
 .ONESHELL:
 setup:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ make run
 ```
 
 Now, to run the script after the system boots, you'll have to follow a few but easy steps:
-1. Run `make config`, to set the appropriate parameters on the *apodwallpaper.service* and *apodwallpaper.py* files (absolute paths of files, in case you're wondering).
+1. Run `make config`, to set the appropriate parameters on the *apodwallpaper.service* (absolute path of the Python script, in case you're wondering).
 2. Now, to enable the *systemd* service, run the make command `make setup`, which does and runs the following (requires **sudo** permissions):
    1. Places the service file inside */etc/systemd/user* (requires **sudo**)
    1. Assign the appropriate permission to the service file by running `sudo chmod 644 /etc/systemd/user/apodwallpaper.service`. (requires **sudo**)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ And, since we're all quite lazy, *systemd* will run the script on startup, after
 ## Dependencies
 
 Well, you need [Python 3](https://www.python.org/), [pip](https://pypi.org/project/pip/), the program [feh](https://feh.finalrewind.org/) and the Python [requests](https://requests.readthedocs.io/en/master/) library.
+To download a video, you'll also need [ffmpeg](https://ffmpeg.org/) and [youtube-dl](https://youtube-dl.org/)
 
 To install the *requests* library, you can run the following command and *pip* will install it using the [requirements.txt](https://github.com/Charly98cma/APOD-Wallpaper/blob/main/requirements.txt) file.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 requests
+ffmpeg
+youtube-dl


### PR DESCRIPTION
This PR adds support for a video image-of-the-day, by first downloading it and then extracting about the first frame of the video.
This makes no promises as to if the frame will be good, but it's better than not having an image at all.
This now needs ffmpeg and youtube-dl to process the frame, but if there's no video of the day, it does not need it.
("Option dependences" in Arch Linux terms)
